### PR TITLE
t/23: Clone editor config

### DIFF
--- a/src/ckfindercommand.js
+++ b/src/ckfindercommand.js
@@ -58,7 +58,7 @@ export default class CKFinderCommand extends Command {
 			throw new CKEditorError( 'ckfinder-unknown-openerMethod: The openerMethod config option must by "popup" or "modal".' );
 		}
 
-		const options = this.editor.config.get( 'ckfinder.options' ) || {};
+		const options = Object.assign( {}, this.editor.config.get( 'ckfinder.options' ) );
 
 		options.chooseFiles = true;
 

--- a/tests/ckfindercommand.js
+++ b/tests/ckfindercommand.js
@@ -384,6 +384,14 @@ describe( 'CKFinderCommand', () => {
 			expect( getModelData( model ) ).to.equal( '<other>[]</other>' );
 		} );
 
+		it( 'does not alter the original config', () => {
+			editor.config.set( 'ckfinder', { options: { foo: 'bar' } } );
+
+			command.execute();
+
+			expect( editor.config.get( 'ckfinder.options' ) ).to.deep.equal( { foo: 'bar' } );
+		} );
+
 		function mockFinderFile( url = 'foo/bar.jpg', isImage = true ) {
 			return {
 				isImage: () => isImage,


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: CKFinderCommand should clone config options from editor.config. Closes #23 .

---

### Additional information

* Bug reporter also here: https://github.com/ckeditor/ckeditor5-utils/issues/257
