### PR TITLE
Remove Easy Image integration from CKFinder documentation snippets.

### DIFF
--- a/docs/_snippets/features/ckfinder-options.js
+++ b/docs/_snippets/features/ckfinder-options.js
@@ -5,11 +5,8 @@
 
 /* globals ClassicEditor, console, window, document */
 
-import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
-
 ClassicEditor
 	.create( document.querySelector( '#snippet-ckfinder-options' ), {
-		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
 				'ckfinder', '|', 'heading', '|', 'bold', 'italic', '|', 'undo', 'redo'

--- a/docs/_snippets/features/ckfinder.js
+++ b/docs/_snippets/features/ckfinder.js
@@ -5,11 +5,8 @@
 
 /* globals ClassicEditor, console, window, document */
 
-import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
-
 ClassicEditor
 	.create( document.querySelector( '#snippet-ckfinder' ), {
-		cloudServices: CS_CONFIG,
 		toolbar: {
 			items: [
 				'ckfinder', '|', 'heading', '|', 'bold', 'italic', '|', 'undo', 'redo'

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "devDependencies": {
     "@ckeditor/ckeditor5-editor-classic": "^11.0.1",
     "@ckeditor/ckeditor5-clipboard": "^10.0.3",
-    "@ckeditor/ckeditor5-cloud-services": "^10.1.0",
     "@ckeditor/ckeditor5-engine": "^11.0.0",
     "@ckeditor/ckeditor5-image": "^11.0.0",
     "@ckeditor/ckeditor5-link": "^10.0.4",

--- a/tests/manual/ckfinder.js
+++ b/tests/manual/ckfinder.js
@@ -11,11 +11,8 @@ import CKFinder from '../../src/ckfinder';
 import ArticlePluginSet from '@ckeditor/ckeditor5-core/tests/_utils/articlepluginset';
 import ImageUpload from '@ckeditor/ckeditor5-image/src/imageupload';
 
-import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
-
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
-		cloudServices: CS_CONFIG,
 		plugins: [ ArticlePluginSet, ImageUpload, CKFinder ],
 		toolbar: [ 'heading', '|', 'undo', 'redo', 'ckfinder' ],
 		image: {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Remove Easy Image integration from CKFinder documentation snippets. Closes #31.

---

### Additional information

* One image is worth 1000 words:

![selection_077](https://user-images.githubusercontent.com/247363/49229442-cf913980-f3ed-11e8-9f76-4271695140ab.png)

