### PR TITLE
Docs: Updated CKFinder path.

### DIFF
--- a/docs/_snippets/features/build-ckfinder-source.html
+++ b/docs/_snippets/features/build-ckfinder-source.html
@@ -1,4 +1,4 @@
-<script src="https://cksource.com/weuy2g4ryt278ywiue/ckfinder.js"></script>
+<script src="https://ckeditor.com/apps/ckfinder/3.4.5/ckfinder.js"></script>
 
 <style>
 	#ckf-modal {

--- a/docs/_snippets/features/ckfinder-options.js
+++ b/docs/_snippets/features/ckfinder-options.js
@@ -15,7 +15,7 @@ ClassicEditor
 		},
 		ckfinder: {
 			// eslint-disable-next-line max-len
-			uploadUrl: 'https://cksource.com/weuy2g4ryt278ywiue/core/connector/php/connector.php?command=QuickUpload&type=Images&responseType=json',
+			uploadUrl: 'https://ckeditor.com/apps/ckfinder/3.4.5/core/connector/php/connector.php?command=QuickUpload&type=Images&responseType=json',
 			options: {
 				height: 600,
 				width: 800,

--- a/docs/_snippets/features/ckfinder-upload-only.js
+++ b/docs/_snippets/features/ckfinder-upload-only.js
@@ -15,7 +15,7 @@ ClassicEditor
 		},
 		ckfinder: {
 			// eslint-disable-next-line max-len
-			uploadUrl: 'https://cksource.com/weuy2g4ryt278ywiue/core/connector/php/connector.php?command=QuickUpload&type=Files&responseType=json'
+			uploadUrl: 'https://ckeditor.com/apps/ckfinder/3.4.5/core/connector/php/connector.php?command=QuickUpload&type=Files&responseType=json'
 		}
 	} )
 	.then( editor => {

--- a/docs/_snippets/features/ckfinder.js
+++ b/docs/_snippets/features/ckfinder.js
@@ -15,7 +15,7 @@ ClassicEditor
 		},
 		ckfinder: {
 			// eslint-disable-next-line max-len
-			uploadUrl: 'https://cksource.com/weuy2g4ryt278ywiue/core/connector/php/connector.php?command=QuickUpload&type=Files&responseType=json',
+			uploadUrl: 'https://ckeditor.com/apps/ckfinder/3.4.5/core/connector/php/connector.php?command=QuickUpload&type=Files&responseType=json',
 			options: {
 				height: 600,
 				width: 800

--- a/tests/manual/ckfinder.html
+++ b/tests/manual/ckfinder.html
@@ -1,5 +1,5 @@
 <head>
-	<meta http-equiv="Content-Security-Policy" content="script-src 'self' https://cksource.com 'unsafe-inline' 'unsafe-eval'">
+	<meta http-equiv="Content-Security-Policy" content="script-src 'self' https://ckeditor.com 'unsafe-inline' 'unsafe-eval'">
 </head>
 
 <script src="https://ckeditor.com/apps/ckfinder/3.4.5/ckfinder.js"></script>

--- a/tests/manual/ckfinder.html
+++ b/tests/manual/ckfinder.html
@@ -2,7 +2,7 @@
 	<meta http-equiv="Content-Security-Policy" content="script-src 'self' https://cksource.com 'unsafe-inline' 'unsafe-eval'">
 </head>
 
-<script src="https://cksource.com/weuy2g4ryt278ywiue/ckfinder.js"></script>
+<script src="https://ckeditor.com/apps/ckfinder/3.4.5/ckfinder.js"></script>
 
 <style>
 	/* Override default test sidebar z-index because CKFinder's modal base z-index is 9000.

--- a/tests/manual/ckfinder.js
+++ b/tests/manual/ckfinder.js
@@ -20,7 +20,7 @@ ClassicEditor
 		},
 		ckfinder: {
 			// eslint-disable-next-line max-len
-			uploadUrl: 'https://cksource.com/weuy2g4ryt278ywiue/core/connector/php/connector.php?command=QuickUpload&type=Files&responseType=json'
+			uploadUrl: 'https://ckeditor.com/apps/ckfinder/3.4.5/core/connector/php/connector.php?command=QuickUpload&type=Files&responseType=json'
 		}
 	} )
 	.then( editor => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Updated CKFinder path to the new location under ckeditor.com domain. Closes #37.

---

### Additional information

Custom build with CORS fixes have been moved to `ckeditor.com/apps`, so it can be used anywhere in docs.