### PR TITLE
Pass CKFinder instance to a user-defined onInit() function.

### DIFF
--- a/src/ckfindercommand.js
+++ b/src/ckfindercommand.js
@@ -73,7 +73,7 @@ export default class CKFinderCommand extends Command {
 		options.onInit = finder => {
 			// Call original options.onInit if it was defined by user.
 			if ( originalOnInit ) {
-				originalOnInit();
+				originalOnInit( finder );
 			}
 
 			finder.on( 'files:choose', evt => {

--- a/tests/ckfindercommand.js
+++ b/tests/ckfindercommand.js
@@ -204,6 +204,16 @@ describe( 'CKFinderCommand', () => {
 			sinon.assert.calledOnce( spy );
 		} );
 
+		it( 'should pass CKFinder instance to a user defined config.onInit() function', () => {
+			const spy = sinon.spy();
+
+			editor.config.set( 'ckfinder.options.onInit', spy );
+
+			command.execute();
+
+			sinon.assert.calledWithExactly( spy, finderMock );
+		} );
+
 		it( 'should pass editor default language to the CKFinder instance', () => {
 			const spy = sinon.spy( window.CKFinder, 'modal' );
 			command.execute();

--- a/tests/ckfindercommand.js
+++ b/tests/ckfindercommand.js
@@ -194,7 +194,7 @@ describe( 'CKFinderCommand', () => {
 			expect( openerMethodOptions ).to.have.property( 'connectorPath', connectorPath );
 		} );
 
-		it( 'should call user defined config.onInit() function', () => {
+		it( 'should call user-defined config.onInit() function', () => {
 			const spy = sinon.spy();
 
 			editor.config.set( 'ckfinder.options.onInit', spy );
@@ -204,7 +204,7 @@ describe( 'CKFinderCommand', () => {
 			sinon.assert.calledOnce( spy );
 		} );
 
-		it( 'should pass CKFinder instance to a user defined config.onInit() function', () => {
+		it( 'should pass CKFinder instance to a user-defined config.onInit() function', () => {
 			const spy = sinon.spy();
 
 			editor.config.set( 'ckfinder.options.onInit', spy );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Pass CKFinder instance to a user-defined `onInit()` function. Closes #45.

---

### Additional information

* I've created a separate test for that case - shouldn't it be tested in an existing "should call user defined config.onInit() function" test?
