### PR TITLE
t/ckeditor5/1151: Aligned the `CKFinderCommand` to the latest Locale API

### DIFF
--- a/src/ckfindercommand.js
+++ b/src/ckfindercommand.js
@@ -66,7 +66,7 @@ export default class CKFinderCommand extends Command {
 
 		// Pass the lang code to the CKFinder if not defined by user.
 		if ( !options.language ) {
-			options.language = editor.locale.language;
+			options.language = editor.locale.uiLanguage;
 		}
 
 		// The onInit method allows to extend CKFinder's behavior. It is used to attach event listeners to file choosing related events.


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Aligned the `CKFinderCommand` to the latest Locale API. See ckeditor/ckeditor5#1151.

---

### Additional information

A piece of https://github.com/ckeditor/ckeditor5/pull/1881.