### PR TITLE
T/48: CKFinder command improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
   "dependencies": {
     "@ckeditor/ckeditor5-adapter-ckfinder": "^11.0.5",
     "@ckeditor/ckeditor5-core": "^12.3.0",
+    "@ckeditor/ckeditor5-image": "^14.0.0",
+    "@ckeditor/ckeditor5-link": "^11.1.2",
     "@ckeditor/ckeditor5-ui": "^14.0.0"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-editor-classic": "^12.1.4",
     "@ckeditor/ckeditor5-clipboard": "^12.0.2",
     "@ckeditor/ckeditor5-engine": "^14.0.0",
-    "@ckeditor/ckeditor5-image": "^14.0.0",
-    "@ckeditor/ckeditor5-link": "^11.1.2",
     "@ckeditor/ckeditor5-paragraph": "^11.0.5",
     "@ckeditor/ckeditor5-utils": "^14.0.0",
     "eslint": "^5.5.0",

--- a/src/ckfindercommand.js
+++ b/src/ckfindercommand.js
@@ -18,6 +18,12 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
  *
  *		editor.execute( 'ckfinder' );
  *
+ * **Note:** At least one of the commands must be available to make this command work:
+ * - To insert images the {@link module:image/image/imageinsertcommand~ImageInsertCommand 'imageInsert'} command
+ * from the {@link module:image/image~Image Image feature}.
+ * - To insert links to files the {@link module:link/linkcommand~LinkCommand 'link'} command
+ * from the {@link module:link/link~Link Link feature}.
+ *
  * @extends module:core/command~Command
  */
 export default class CKFinderCommand extends Command {

--- a/src/ckfindercommand.js
+++ b/src/ckfindercommand.js
@@ -42,7 +42,7 @@ export default class CKFinderCommand extends Command {
 		const linkCommand = this.editor.commands.get( 'link' );
 
 		// The CKFinder command is enabled when one of image or link command is enabled.
-		this.isEnabled = imageCommand && linkCommand && ( imageCommand.isEnabled || linkCommand.isEnabled );
+		this.isEnabled = imageCommand && imageCommand.isEnabled || linkCommand && linkCommand.isEnabled;
 	}
 
 	/**

--- a/src/ckfindercommand.js
+++ b/src/ckfindercommand.js
@@ -38,7 +38,7 @@ export default class CKFinderCommand extends Command {
 	 * @inheritDoc
 	 */
 	refresh() {
-		const imageCommand = this.editor.commands.get( 'imageUpload' );
+		const imageCommand = this.editor.commands.get( 'imageInsert' );
 		const linkCommand = this.editor.commands.get( 'link' );
 
 		// The CKFinder command is enabled when one of image or link command is enabled.
@@ -124,7 +124,7 @@ export default class CKFinderCommand extends Command {
 }
 
 function insertImages( editor, urls ) {
-	const imageCommand = editor.commands.get( 'imageUpload' );
+	const imageCommand = editor.commands.get( 'imageInsert' );
 
 	// Check if inserting an image is actually possible - it might be possible to only insert a link.
 	if ( !imageCommand.isEnabled ) {

--- a/src/ckfindercommand.js
+++ b/src/ckfindercommand.js
@@ -89,18 +89,8 @@ export default class CKFinderCommand extends Command {
 				const links = files.filter( file => !file.isImage() );
 				const images = files.filter( file => file.isImage() );
 
-				if ( !editor.commands.get( 'link' ) ) {
-					const notification = editor.plugins.get( 'Notification' );
-					const t = editor.locale.t;
-
-					notification.showWarning( t( 'The "link" command must be available to insert links.' ), {
-						title: t( 'Inserting link failed' ),
-						namespace: 'ckfinder'
-					} );
-				} else {
-					for ( const linkFile of links ) {
-						editor.execute( 'link', linkFile.getUrl() );
-					}
+				for ( const linkFile of links ) {
+					editor.execute( 'link', linkFile.getUrl() );
 				}
 
 				const imagesUrls = [];
@@ -141,18 +131,6 @@ export default class CKFinderCommand extends Command {
 
 function insertImages( editor, urls ) {
 	const imageCommand = editor.commands.get( 'imageInsert' );
-
-	if ( !imageCommand ) {
-		const notification = editor.plugins.get( 'Notification' );
-		const t = editor.locale.t;
-
-		notification.showWarning( t( 'The "imageInsert" command must be available to insert images.' ), {
-			title: t( 'Inserting image failed' ),
-			namespace: 'ckfinder'
-		} );
-
-		return;
-	}
 
 	// Check if inserting an image is actually possible - it might be possible to only insert a link.
 	if ( !imageCommand.isEnabled ) {

--- a/src/ckfindercommand.js
+++ b/src/ckfindercommand.js
@@ -47,11 +47,8 @@ export default class CKFinderCommand extends Command {
 		const imageCommand = this.editor.commands.get( 'imageInsert' );
 		const linkCommand = this.editor.commands.get( 'link' );
 
-		const canUseImageCommand = !!( imageCommand && imageCommand.isEnabled );
-		const canUseLinkCommand = !!( linkCommand && linkCommand.isEnabled );
-
 		// The CKFinder command is enabled when one of image or link command is enabled.
-		this.isEnabled = canUseImageCommand || canUseLinkCommand;
+		this.isEnabled = imageCommand.isEnabled || linkCommand.isEnabled;
 	}
 
 	/**

--- a/src/ckfindercommand.js
+++ b/src/ckfindercommand.js
@@ -13,7 +13,7 @@ import Command from '@ckeditor/ckeditor5-core/src/command';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 /**
- * The CKFinder command. It is used by the {@link module:ckfinder/ckfinderediting~CKFinderEditing ckfinder editng feature}
+ * The CKFinder command. It is used by the {@link module:ckfinder/ckfinderediting~CKFinderEditing ckfinder editing feature}
  * to open a CKFinder file browser to insert an image or a link to a file into content.
  *
  *		editor.execute( 'ckfinder' );

--- a/src/ckfindercommand.js
+++ b/src/ckfindercommand.js
@@ -18,7 +18,7 @@ import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
  *
  *		editor.execute( 'ckfinder' );
  *
- * **Note:** At least one of the commands must be available to make this command work:
+ * **Note:** This command uses other features to perform tasks:
  * - To insert images the {@link module:image/image/imageinsertcommand~ImageInsertCommand 'imageInsert'} command
  * from the {@link module:image/image~Image Image feature}.
  * - To insert links to files the {@link module:link/linkcommand~LinkCommand 'link'} command

--- a/src/ckfinderediting.js
+++ b/src/ckfinderediting.js
@@ -8,6 +8,8 @@
  */
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
+import Image from '@ckeditor/ckeditor5-image/src/image';
+import Link from '@ckeditor/ckeditor5-link/src/link';
 import Notification from '@ckeditor/ckeditor5-ui/src/notification/notification';
 
 import CKFinderCommand from './ckfindercommand';
@@ -29,7 +31,7 @@ export default class CKFinderEditing extends Plugin {
 	 * @inheritDoc
 	 */
 	static get requires() {
-		return [ Notification ];
+		return [ Notification, Image, Link ];
 	}
 
 	/**

--- a/tests/ckfindercommand.js
+++ b/tests/ckfindercommand.js
@@ -128,22 +128,6 @@ describe( 'CKFinderCommand', () => {
 			command.refresh();
 			expect( command.isEnabled ).to.be.true;
 		} );
-
-		it( 'should be true when imageInsert command is not available', () => {
-			setModelData( model, '<paragraph>[]</paragraph>' );
-			const insertImage = editor.commands.get( 'imageInsert' );
-			editor.commands._commands.delete( 'link' );
-
-			insertImage.isEnabled = false;
-
-			command.refresh();
-			expect( command.isEnabled ).to.be.false;
-
-			insertImage.isEnabled = true;
-
-			command.refresh();
-			expect( command.isEnabled ).to.be.true;
-		} );
 	} );
 
 	describe( 'execute()', () => {

--- a/tests/ckfindercommand.js
+++ b/tests/ckfindercommand.js
@@ -104,6 +104,24 @@ describe( 'CKFinderCommand', () => {
 
 			expect( command.isEnabled ).to.be.false;
 		} );
+
+		it( 'should be true when imageInsert and link command are enabled', () => {
+			setModelData( model, '<paragraph>[]</paragraph>' );
+			const insertImage = editor.commands.get( 'imageInsert' );
+			const linkCommand = editor.commands.get( 'link' );
+
+			insertImage.isEnabled = false;
+			linkCommand.isEnabled = false;
+
+			command.refresh();
+			expect( command.isEnabled ).to.be.false;
+
+			linkCommand.isEnabled = true;
+			insertImage.isEnabled = true;
+
+			command.refresh();
+			expect( command.isEnabled ).to.be.true;
+		} );
 	} );
 
 	describe( 'execute()', () => {

--- a/tests/ckfindercommand.js
+++ b/tests/ckfindercommand.js
@@ -105,7 +105,7 @@ describe( 'CKFinderCommand', () => {
 			expect( command.isEnabled ).to.be.false;
 		} );
 
-		it( 'should be true when imageInsert and link command are enabled', () => {
+		it( 'should be true when imageInsert or link command is enabled', () => {
 			setModelData( model, '<paragraph>[]</paragraph>' );
 			const insertImage = editor.commands.get( 'imageInsert' );
 			const linkCommand = editor.commands.get( 'link' );
@@ -116,8 +116,14 @@ describe( 'CKFinderCommand', () => {
 			command.refresh();
 			expect( command.isEnabled ).to.be.false;
 
-			linkCommand.isEnabled = true;
+			linkCommand.isEnabled = false;
 			insertImage.isEnabled = true;
+
+			command.refresh();
+			expect( command.isEnabled ).to.be.true;
+
+			linkCommand.isEnabled = true;
+			insertImage.isEnabled = false;
 
 			command.refresh();
 			expect( command.isEnabled ).to.be.true;

--- a/tests/ckfindercommand.js
+++ b/tests/ckfindercommand.js
@@ -128,6 +128,22 @@ describe( 'CKFinderCommand', () => {
 			command.refresh();
 			expect( command.isEnabled ).to.be.true;
 		} );
+
+		it( 'should be true when imageInsert command is not available', () => {
+			setModelData( model, '<paragraph>[]</paragraph>' );
+			const insertImage = editor.commands.get( 'imageInsert' );
+			editor.commands._commands.delete( 'link' );
+
+			insertImage.isEnabled = false;
+
+			command.refresh();
+			expect( command.isEnabled ).to.be.false;
+
+			insertImage.isEnabled = true;
+
+			command.refresh();
+			expect( command.isEnabled ).to.be.true;
+		} );
 	} );
 
 	describe( 'execute()', () => {
@@ -398,6 +414,42 @@ describe( 'CKFinderCommand', () => {
 
 			expect( getModelData( model ) )
 				.to.equal( '<paragraph>f[o]o</paragraph>' );
+		} );
+
+		it( 'should show warning notification if link command is not available', done => {
+			// Remove link command.
+			editor.commands._commands.delete( 'link' );
+			const notification = editor.plugins.get( Notification );
+
+			notification.on( 'show:warning', ( evt, data ) => {
+				expect( data.message ).to.equal( 'The "link" command must be available to insert links.' );
+				expect( data.title ).to.equal( 'Inserting link failed' );
+				evt.stop();
+
+				done();
+			}, { priority: 'high' } );
+
+			command.execute();
+
+			mockFilesChooseEvent( [ mockFinderFile( 'foo/bar.pdf', false ) ] );
+		} );
+
+		it( 'should show warning notification if link command is not available', done => {
+			// Remove link command.
+			editor.commands._commands.delete( 'imageInsert' );
+			const notification = editor.plugins.get( Notification );
+
+			notification.on( 'show:warning', ( evt, data ) => {
+				expect( data.message ).to.equal( 'The "imageInsert" command must be available to insert images.' );
+				expect( data.title ).to.equal( 'Inserting image failed' );
+				evt.stop();
+
+				done();
+			}, { priority: 'high' } );
+
+			command.execute();
+
+			mockFilesChooseEvent( [ mockFinderFile( 'foo/bar.png', true ) ] );
 		} );
 
 		it( 'should not insert image nor crash when image could not be inserted', () => {

--- a/tests/ckfindercommand.js
+++ b/tests/ckfindercommand.js
@@ -400,42 +400,6 @@ describe( 'CKFinderCommand', () => {
 				.to.equal( '<paragraph>f[o]o</paragraph>' );
 		} );
 
-		it( 'should show warning notification if link command is not available', done => {
-			// Remove link command.
-			editor.commands._commands.delete( 'link' );
-			const notification = editor.plugins.get( Notification );
-
-			notification.on( 'show:warning', ( evt, data ) => {
-				expect( data.message ).to.equal( 'The "link" command must be available to insert links.' );
-				expect( data.title ).to.equal( 'Inserting link failed' );
-				evt.stop();
-
-				done();
-			}, { priority: 'high' } );
-
-			command.execute();
-
-			mockFilesChooseEvent( [ mockFinderFile( 'foo/bar.pdf', false ) ] );
-		} );
-
-		it( 'should show warning notification if link command is not available', done => {
-			// Remove link command.
-			editor.commands._commands.delete( 'imageInsert' );
-			const notification = editor.plugins.get( Notification );
-
-			notification.on( 'show:warning', ( evt, data ) => {
-				expect( data.message ).to.equal( 'The "imageInsert" command must be available to insert images.' );
-				expect( data.title ).to.equal( 'Inserting image failed' );
-				evt.stop();
-
-				done();
-			}, { priority: 'high' } );
-
-			command.execute();
-
-			mockFilesChooseEvent( [ mockFinderFile( 'foo/bar.png', true ) ] );
-		} );
-
 		it( 'should not insert image nor crash when image could not be inserted', () => {
 			model.schema.register( 'other', {
 				allowIn: '$root',

--- a/tests/ckfinderediting.js
+++ b/tests/ckfinderediting.js
@@ -6,6 +6,8 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
+import Image from '@ckeditor/ckeditor5-image/src/image';
+import Link from '@ckeditor/ckeditor5-link/src/link';
 import Notification from '@ckeditor/ckeditor5-ui/src/notification/notification';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 
@@ -43,6 +45,14 @@ describe( 'CKFinderEditing', () => {
 
 	it( 'should load Notification plugin', () => {
 		expect( editor.plugins.get( Notification ) ).to.instanceOf( Notification );
+	} );
+
+	it( 'should load Image plugin', () => {
+		expect( editor.plugins.get( Image ) ).to.instanceOf( Image );
+	} );
+
+	it( 'should load Link plugin', () => {
+		expect( editor.plugins.get( Link ) ).to.instanceOf( Link );
 	} );
 
 	it( 'should register command', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: CKFinderCommand should work with either 'link' or 'imageInsert' commands not available. Closes #48.

---

### Additional information

* First commits fixes the issue with `'imageUpload'` command use instead of `insertImage'`.
* The latter part enables CKFinderCommand to work without one of: link or image insert commands. So if link command is not available and user selects a non-image file then a warning is displayed.
