### PR TITLE
Make CKFinderEditing require ImageEditing & LinkEditing

### DIFF
--- a/src/ckfinderediting.js
+++ b/src/ckfinderediting.js
@@ -8,8 +8,8 @@
  */
 
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
-import Image from '@ckeditor/ckeditor5-image/src/image';
-import Link from '@ckeditor/ckeditor5-link/src/link';
+import ImageEditing from '@ckeditor/ckeditor5-image/src/image/imageediting';
+import LinkEditing from '@ckeditor/ckeditor5-link/src/linkediting';
 import Notification from '@ckeditor/ckeditor5-ui/src/notification/notification';
 
 import CKFinderCommand from './ckfindercommand';
@@ -31,7 +31,7 @@ export default class CKFinderEditing extends Plugin {
 	 * @inheritDoc
 	 */
 	static get requires() {
-		return [ Notification, Image, Link ];
+		return [ Notification, ImageEditing, LinkEditing ];
 	}
 
 	/**

--- a/tests/ckfinderediting.js
+++ b/tests/ckfinderediting.js
@@ -6,8 +6,8 @@
 import Command from '@ckeditor/ckeditor5-core/src/command';
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
-import Image from '@ckeditor/ckeditor5-image/src/image';
-import Link from '@ckeditor/ckeditor5-link/src/link';
+import ImageEditing from '@ckeditor/ckeditor5-image/src/image/imageediting';
+import LinkEditing from '@ckeditor/ckeditor5-link/src/linkediting';
 import Notification from '@ckeditor/ckeditor5-ui/src/notification/notification';
 import global from '@ckeditor/ckeditor5-utils/src/dom/global';
 
@@ -47,12 +47,12 @@ describe( 'CKFinderEditing', () => {
 		expect( editor.plugins.get( Notification ) ).to.instanceOf( Notification );
 	} );
 
-	it( 'should load Image plugin', () => {
-		expect( editor.plugins.get( Image ) ).to.instanceOf( Image );
+	it( 'should load ImageEditing plugin', () => {
+		expect( editor.plugins.get( ImageEditing ) ).to.instanceOf( ImageEditing );
 	} );
 
-	it( 'should load Link plugin', () => {
-		expect( editor.plugins.get( Link ) ).to.instanceOf( Link );
+	it( 'should load LinkEditing plugin', () => {
+		expect( editor.plugins.get( LinkEditing ) ).to.instanceOf( LinkEditing );
 	} );
 
 	it( 'should register command', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Make CKFinderEditing require ImageEditing & LinkEditing. Closes ckeditor/ckeditor5#5599.

---

### Additional information

* Previously required Image and Link would cause errors because they could be removed by removePlugins config option.
* This PR only fixes the issue with `CKFinder` - other plugins might have similar problems (e.g. `ImageUploadEditing` should require `ImageEditing` but this should be done with https://github.com/ckeditor/ckeditor5/issues/5602 IMO.
