### PR TITLE
Replaced an example URL to CKFinder library with working from ckeditor.com

### DIFF
--- a/docs/features/ckfinder.md
+++ b/docs/features/ckfinder.md
@@ -92,7 +92,7 @@ To use both the image upload functionality and the file manager user interface i
 The easiest way to load the CKFinder library is to include the `<script>` tag loading the `ckfinder.js` file first:
 
 ```html
-<script src="https://example.com/ckfinder/ckfinder.js"></script>
+<script src="https://ckeditor.com/apps/ckfinder/3.5.0/ckfinder.js"></script>
 ```
 
 Then:


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Replaced an example URL to CKFinder library with working from ckeditor.com. Closes ckeditor/ckeditor5#5830.
